### PR TITLE
Switch to using channel name in the join group slash command to be mo…

### DIFF
--- a/app/groups_read.py
+++ b/app/groups_read.py
@@ -3,14 +3,22 @@ NO_AFFINITY_GROUPS_RESPONSE = 'No affinity groups found. To populate this list, 
     'channels.'
 
 
+def find_private_channels(client):
+    # Permissions note:
+    # Bot presence (in a channel) is how we're managing which channels show in the list.
+    # Thus, this must be some form of bot token (xoxb). Only groups.list scope is required.
+    return client.api_call(
+        api_method='conversations.list',
+        params={'types': 'private_channel', 'exclude_archived': 'true'}
+    )
+
+
 def get_groups_list(client):
     # Permissions note:
     # Bot presence (in a channel) is how we're managing which channels show in the list.
     # Thus, this must be some form of bot token (xoxb). Only groups.list scope is required.
-    response = client.api_call(
-        api_method='conversations.list',
-        params={'types': 'private_channel', 'exclude_archived': 'true'}
-    )
+    response = find_private_channels(client)
+
     assert response['ok']
 
     return _build_list_response(response)
@@ -34,6 +42,6 @@ def _build_list_response(slack_response):
     for c in channels:
         response += f":slack: *{ c['name'] }* --"
         response += '(No topic provided)' if c['topic'] == '' else c['topic']
-        response += f" -- `/join-group { c['id'] }`\n"
+        response += f" -- `/join-group { c['name'] }`\n"
 
     return response

--- a/app/groups_write.py
+++ b/app/groups_write.py
@@ -1,3 +1,7 @@
+from app.groups_read import find_private_channels
+
+UNKNOWN_CHANNEL_ERROR = 'Sorry there is no channel to join with that name. Available channel names should appear '\
+                       'after running the `/list-groups` command'
 INVITE_USER_STRING = 'Someone would like to join this affinity group. Press the confirm button to invite that user.'
 USER_INVITED_STRING = 'New user invited to the channel!'
 STATE_DIVIDER = '@@!!@@!!@@'
@@ -28,8 +32,18 @@ def _get_invite_user_blocks(user_id, channel_id, oauth_URI, message_ts=''):
         }]
 
 
+def _lookup_channel_id_from_name(client, channel_name):
+    for channel in find_private_channels(client).get('channels'):
+        if channel['name'] == channel_name:
+            return channel['id']
+
+
 def request_to_join_group(client, form_data, oauth_URI):
-    group_to_join = form_data['text']
+    group_to_join = _lookup_channel_id_from_name(client, form_data['text'])
+
+    if not group_to_join:
+        return UNKNOWN_CHANNEL_ERROR
+
     user_requesting_to_join = form_data['user_id']
     invite_user_button = _get_invite_user_blocks(user_requesting_to_join, group_to_join, oauth_URI)
 

--- a/test/test_group_read.py
+++ b/test/test_group_read.py
@@ -34,15 +34,15 @@ class GetGroupsListTests(TestCase):
 
     @mock.patch('slack.WebClient')
     def test_returns_list_of_groups(self, MockClient):
-        mock_channel_id = 'such id'
-        mock_channel = {'id': mock_channel_id, 'name': 'such name', 'topic': {'value': 'such topic '}}
+        mock_channel_name = 'such name'
+        mock_channel = {'id': 'such id', 'name': mock_channel_name, 'topic': {'value': 'such topic '}}
         mock_api_response = {'ok': True, 'channels': [mock_channel]}
 
         MockClient.return_value.api_call.return_value = mock_api_response
 
         actual = get_groups_list(MockClient())
 
-        assert mock_channel_id in actual
+        assert mock_channel_name in actual
 
     @mock.patch('slack.WebClient')
     def test_returns_placeholder_topic_when_none_provided(self, MockClient):


### PR DESCRIPTION
…re user friendly

This is the corresponding [pivotal story](https://www.pivotaltracker.com/story/show/167649852) requesting the change in the UI to use the channel name parameter in the `/join-group` slash command instead of an ugly channel id.

We aren't caching the private channels list anywhere so this costs an extra api query to match the name back up.  The channel list would change if a slackbot is added or removed from the private channel.

There is now an error message though if the channel name is unrecognized, there was none in the past for an unknown channel id.  The error message shouldn't leak any info about a channel existing because we only query for channels the bot is installed in.

**Updated w/ changes**:
![Screen Shot 2019-08-06 at 7 02 09 PM](https://user-images.githubusercontent.com/52669884/62583119-e3dedd80-b87c-11e9-8579-2210850d7381.png)

**Existing version**:
![Screen Shot 2019-08-06 at 7 02 35 PM](https://user-images.githubusercontent.com/52669884/62583127-eb05eb80-b87c-11e9-8110-86ce94552f1f.png)
