### PR TITLE
Replace `assert thing` logic with `if not thing`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,8 @@ def query_team_id(slack_bot_token):
     response = client.api_call(
         api_method='team.info'
     )
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
     return response['team']['id']
 

--- a/app/groups_read.py
+++ b/app/groups_read.py
@@ -19,7 +19,8 @@ def get_groups_list(client):
     # Thus, this must be some form of bot token (xoxb). Only groups.list scope is required.
     response = find_private_channels(client)
 
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
     return _build_list_response(response)
 

--- a/app/groups_write.py
+++ b/app/groups_write.py
@@ -53,7 +53,8 @@ def request_to_join_group(client, form_data, oauth_URI):
     response = client.chat_postMessage(
         channel=group_to_join,
         blocks=invite_user_button)
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
     message_id = response.data['ts']
     response = client.chat_update(
@@ -61,7 +62,8 @@ def request_to_join_group(client, form_data, oauth_URI):
         ts=message_id,
         blocks=_get_invite_user_blocks(user_requesting_to_join, group_to_join, oauth_URI, message_id)
     )
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
     return f"Alright! I've posted the following message to the private channel:\n> { INVITE_USER_STRING }"
 
@@ -83,7 +85,8 @@ def _replace_confirm_invite_button_with_success_message(client, channel, timesta
         ts=timestamp,
         as_user=True,
     )
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
 
 def invite_user_to_group(user_client, bot_client, oauth_state):
@@ -93,7 +96,8 @@ def invite_user_to_group(user_client, bot_client, oauth_state):
         api_method='groups.invite',
         params={'channel': invite_channel_id, 'user': invite_user_id}
     )
-    assert response['ok']
+    if not response['ok']:
+        raise AssertionError
 
     _replace_confirm_invite_button_with_success_message(bot_client, invite_channel_id, invite_message_ts)
 

--- a/app/groups_write.py
+++ b/app/groups_write.py
@@ -1,7 +1,9 @@
 from app.groups_read import find_private_channels
 
-UNKNOWN_CHANNEL_ERROR = 'Sorry there is no channel to join with that name. Available channel names should appear '\
-                       'after running the `/list-groups` command'
+UNKNOWN_CHANNEL_ERROR = (
+    'Sorry there is no channel to join with that name. Available channel names should appear '
+    'after running the `/list-groups` command'
+)
 INVITE_USER_STRING = 'Someone would like to join this affinity group. Press the confirm button to invite that user.'
 USER_INVITED_STRING = 'New user invited to the channel!'
 STATE_DIVIDER = '@@!!@@!!@@'


### PR DESCRIPTION
In python, `assert` is intended to debug one's own code, rather than to check for externally driven failure states. Therefore, `assert` will be compiled out if the script is called with `python -O` or if `__debug__` is otherwise not truthy. 

See: https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement

> The current code generator emits no code for an assert statement 
> when optimization is requested at compile time.

See also: https://wiki.python.org/moin/UsingAssertionsEffectively

> Assertions should *not* be used to test for failure cases that can
> occur because of bad user input or operating system/environment
> failures, such as a file not being found. Instead, you should raise an
> exception, or print an error message, or whatever is appropriate. One
> important reason why assertions should only be used for self-tests of
> the program is that assertions can be disabled at compile time.

This pull request transforms assertions into explicit state checks using `if not ... then raise`. 

For consistency with previously expected behavior, `AssertionError` is raised. If another error type would be better, please let me know, or feel free to add commits to this branch.