### PR TITLE
changed decrypted API call with new ones

### DIFF
--- a/app/groups_write.py
+++ b/app/groups_write.py
@@ -101,8 +101,8 @@ def invite_user_to_group(user_client, bot_client, oauth_state):
     invite_user_id, invite_channel_id, invite_message_ts = oauth_state.split(STATE_DIVIDER)
 
     response = user_client.api_call(
-        api_method='groups.invite',
-        params={'channel': invite_channel_id, 'user': invite_user_id}
+        api_method='coversations.invite',
+        params={'channel': invite_channel_id, 'users': invite_user_id}
     )
     if not response['ok']:
         raise AssertionError

--- a/app/groups_write.py
+++ b/app/groups_write.py
@@ -101,7 +101,7 @@ def invite_user_to_group(user_client, bot_client, oauth_state):
     invite_user_id, invite_channel_id, invite_message_ts = oauth_state.split(STATE_DIVIDER)
 
     response = user_client.api_call(
-        api_method='coversations.invite',
+        api_method='conversations.invite',
         params={'channel': invite_channel_id, 'users': invite_user_id}
     )
     if not response['ok']:

--- a/test/test_group_write.py
+++ b/test/test_group_write.py
@@ -120,7 +120,7 @@ class InviteUserToGroupTests(TestCase):
         mock_user = 'mock user'
         mock_timestamp = 'mock timestamp'
         mock_oauth_state = STATE_DIVIDER.join([mock_user, mock_channel, mock_timestamp])
-        expected_params = {'channel': mock_channel, 'user': mock_user}
+        expected_params = {'channel': mock_channel, 'users': mock_user}
 
         # act
         invite_user_to_group(MockClient(), MockClient(), mock_oauth_state)
@@ -128,7 +128,7 @@ class InviteUserToGroupTests(TestCase):
         # assert
         MockClient.return_value.api_call.assert_called_once()
         MockClient.return_value.api_call.assert_called_once_with(
-            api_method='groups.invite',
+            api_method='conversations.invite',
             params=expected_params)
 
     @mock.patch('slack.WebClient')


### PR DESCRIPTION
[Tracker Story](https://www.pivotaltracker.com/story/show/177855214)

Slack decrypted some API calls. changed groups.invite to conversations.invite