### PR TITLE
use main branch of validate-python gha

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   validate:
-    uses: trussworks/shared-actions/.github/workflows/validate-python.yml@validate-python
+    uses: trussworks/shared-actions/.github/workflows/validate-python.yml@main
     with:
       python-version: "3.9"


### PR DESCRIPTION
Changes proposed in this pull request:

- Use main branch of the GHA now that it's been tested and merged into main branch of `shared-actions`
