### PR TITLE
chore: fixes python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye as python-build-stage
+FROM python:3.13-slim-bullseye AS python-build-stage
 WORKDIR /src
 
 RUN apt-get update && apt-get upgrade -y \
@@ -11,10 +11,10 @@ RUN pip install --isolated --no-cache-dir --no-input poetry \
     && poetry config virtualenvs.create false \
     && poetry install --no-interaction --without=dev
 
-FROM public.ecr.aws/lambda/python:3.13 as python-run-stage
+FROM public.ecr.aws/lambda/python:3.13 AS python-run-stage
 
-COPY --from=python-build-stage /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
-ENV PYTHONPATH=/usr/local/lib/python3.10/site-packages
+COPY --from=python-build-stage /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.13/site-packages
 
 COPY handler.py ${LAMBDA_TASK_ROOT}
 COPY groups_read.py ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION
In a previous PR, I updated Python, but we hard code the version in the Dockerfile. This updates the Dockerfile with 3.13.
